### PR TITLE
resize job announcement section

### DIFF
--- a/resources/assets/ts/pages/home/Index.tsx
+++ b/resources/assets/ts/pages/home/Index.tsx
@@ -36,7 +36,7 @@ const Home = () => {
             </p>
             <InertiaLink
               href="/jobs"
-              className="p-2 bg-brand-100 items-center text-gray-700 rounded-lg md:rounded-full flex lg:inline-flex w-full"
+              className="p-2 bg-brand-100 items-center text-gray-700 rounded-lg md:rounded-full flex lg:inline-flex"
               role="alert"
             >
               <span className="flex rounded-lg md:rounded-full bg-brand-900 uppercase px-2 py-1 text-xs font-bold mr-4 text-white">


### PR DESCRIPTION
removed "w-full" class to make sure the job section announcement in the hero section doesn't expand into the svg on wide screen